### PR TITLE
Expose a functionality using which theatre admins can create a show

### DIFF
--- a/src/main/java/com/jshubham/bookmyshow/controllers/ShowController.java
+++ b/src/main/java/com/jshubham/bookmyshow/controllers/ShowController.java
@@ -1,0 +1,49 @@
+package com.jshubham.bookmyshow.controllers;
+
+import com.jshubham.bookmyshow.dtos.CreateShowRequestDTO;
+import com.jshubham.bookmyshow.dtos.CreateShowResponseDTO;
+import com.jshubham.bookmyshow.dtos.ResponseStatus;
+import com.jshubham.bookmyshow.models.Show;
+import com.jshubham.bookmyshow.models.enums.Feature;
+import com.jshubham.bookmyshow.models.enums.SeatType;
+import com.jshubham.bookmyshow.services.ShowService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Controller;
+
+import java.util.Date;
+import java.util.List;
+
+@Controller
+public class ShowController {
+
+    private ShowService showService;
+
+
+    @Autowired
+    public ShowController(ShowService showService) {
+        this.showService = showService;
+    }
+
+
+    public CreateShowResponseDTO createShow(CreateShowRequestDTO requestDTO) {
+        CreateShowResponseDTO responseDTO = new CreateShowResponseDTO();
+        Long movieId = requestDTO.getMovieId();
+        Long userId = requestDTO.getUserId();
+        Long screenId = requestDTO.getScreenId();
+        Date startTime = requestDTO.getStartTime();
+        Date endTime = requestDTO.getEndTime();
+        List<Feature> features = requestDTO.getFeatures();
+        List<Pair<SeatType, Double>> pricingConfig = requestDTO.getPricingConfig();
+
+        try {
+            Show show = showService.createShow(userId, movieId, screenId, startTime, endTime, pricingConfig, features);
+            responseDTO.setShow(show);
+            responseDTO.setResponseStatus(ResponseStatus.SUCCESS);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            responseDTO.setResponseStatus(ResponseStatus.FAILURE);
+        }
+        return responseDTO;
+    }
+}

--- a/src/main/java/com/jshubham/bookmyshow/dtos/CreateShowRequestDTO.java
+++ b/src/main/java/com/jshubham/bookmyshow/dtos/CreateShowRequestDTO.java
@@ -1,0 +1,20 @@
+package com.jshubham.bookmyshow.dtos;
+
+import com.jshubham.bookmyshow.models.enums.Feature;
+import com.jshubham.bookmyshow.models.enums.SeatType;
+import lombok.Data;
+import org.springframework.data.util.Pair;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+public class CreateShowRequestDTO {
+    private Long movieId;
+    private Long userId;
+    private Long screenId;
+    private Date startTime;
+    private Date endTime;
+    private List<Feature> features;
+    private List<Pair<SeatType, Double>> pricingConfig;
+}

--- a/src/main/java/com/jshubham/bookmyshow/dtos/CreateShowResponseDTO.java
+++ b/src/main/java/com/jshubham/bookmyshow/dtos/CreateShowResponseDTO.java
@@ -1,0 +1,10 @@
+package com.jshubham.bookmyshow.dtos;
+
+import com.jshubham.bookmyshow.models.Show;
+import lombok.Data;
+
+@Data
+public class CreateShowResponseDTO {
+    private ResponseStatus responseStatus;
+    private Show show;
+}

--- a/src/main/java/com/jshubham/bookmyshow/exceptions/FeatureNotSupportedByScreen.java
+++ b/src/main/java/com/jshubham/bookmyshow/exceptions/FeatureNotSupportedByScreen.java
@@ -1,0 +1,7 @@
+package com.jshubham.bookmyshow.exceptions;
+
+public class FeatureNotSupportedByScreen extends RuntimeException {
+    public FeatureNotSupportedByScreen(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jshubham/bookmyshow/exceptions/InvalidDateException.java
+++ b/src/main/java/com/jshubham/bookmyshow/exceptions/InvalidDateException.java
@@ -1,0 +1,7 @@
+package com.jshubham.bookmyshow.exceptions;
+
+public class InvalidDateException extends RuntimeException {
+    public InvalidDateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jshubham/bookmyshow/exceptions/MovieNotFoundException.java
+++ b/src/main/java/com/jshubham/bookmyshow/exceptions/MovieNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jshubham.bookmyshow.exceptions;
+
+public class MovieNotFoundException extends RuntimeException {
+    public MovieNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jshubham/bookmyshow/exceptions/ScreenNotFoundException.java
+++ b/src/main/java/com/jshubham/bookmyshow/exceptions/ScreenNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jshubham.bookmyshow.exceptions;
+
+public class ScreenNotFoundException extends RuntimeException {
+    public ScreenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jshubham/bookmyshow/exceptions/UnAuthorizedAccessException.java
+++ b/src/main/java/com/jshubham/bookmyshow/exceptions/UnAuthorizedAccessException.java
@@ -1,0 +1,7 @@
+package com.jshubham.bookmyshow.exceptions;
+
+public class UnAuthorizedAccessException extends RuntimeException {
+    public UnAuthorizedAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/jshubham/bookmyshow/models/Screen.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/Screen.java
@@ -1,6 +1,7 @@
 package com.jshubham.bookmyshow.models;
 
 import com.jshubham.bookmyshow.models.enums.Feature;
+import com.jshubham.bookmyshow.models.enums.ScreenStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,8 +14,15 @@ import java.util.List;
 public class Screen extends BaseModel{
     private String name;
 
-    @OneToMany
+    @ManyToOne
+    private Theatre theatre;
+
+    @OneToMany(mappedBy = "screen")
+    // @JoinColumn(name = "screen_id") // will create FK in Seats table with name screen_id
     private List<Seat> seats;
+
+    @Enumerated(EnumType.ORDINAL)
+    private ScreenStatus status;
 
     @Enumerated(EnumType.ORDINAL)
     @ElementCollection

--- a/src/main/java/com/jshubham/bookmyshow/models/Seat.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/Seat.java
@@ -4,6 +4,7 @@ import com.jshubham.bookmyshow.models.enums.SeatType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -17,4 +18,7 @@ public class Seat extends BaseModel{
 
     @Enumerated(EnumType.ORDINAL)
     private SeatType seatType;
+
+    @ManyToOne
+    Screen screen;
 }

--- a/src/main/java/com/jshubham/bookmyshow/models/Show.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/Show.java
@@ -18,6 +18,11 @@ public class Show extends BaseModel{
     private Date startTime;
     private Date endTime;
 
+    @OneToMany(mappedBy = "show")
+    private List<ShowSeat> showSeats;
+    @OneToMany(mappedBy = "show")
+    private List<ShowSeatType> showSeatTypes;
+
     @ManyToOne
     private Screen screen;
 

--- a/src/main/java/com/jshubham/bookmyshow/models/ShowSeat.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/ShowSeat.java
@@ -17,5 +17,5 @@ public class ShowSeat extends BaseModel{
     @ManyToOne
     private Seat seat;
     @Enumerated(EnumType.ORDINAL)
-    private ShowSeatStatus showSeatStatus;
+    private ShowSeatStatus status;
 }

--- a/src/main/java/com/jshubham/bookmyshow/models/ShowSeatType.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/ShowSeatType.java
@@ -16,7 +16,7 @@ public class ShowSeatType extends BaseModel{
     private Show show;
     @Enumerated(EnumType.ORDINAL)
     private SeatType seatType;
-    private int price;
+    private double price;
 }
 /**
  * Show - X, Y, Z

--- a/src/main/java/com/jshubham/bookmyshow/models/Theatre.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/Theatre.java
@@ -1,6 +1,7 @@
 package com.jshubham.bookmyshow.models;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.Getter;
@@ -17,6 +18,6 @@ public class Theatre extends BaseModel{
     @ManyToOne
     private Region region;
 
-    @OneToMany
+    @OneToMany(mappedBy = "theatre")
     List<Screen> screens;
 }

--- a/src/main/java/com/jshubham/bookmyshow/models/User.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/User.java
@@ -1,6 +1,9 @@
 package com.jshubham.bookmyshow.models;
 
+import com.jshubham.bookmyshow.models.enums.UserType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,6 +18,15 @@ public class User extends BaseModel{
     private String email;
     private String password;
 
-    @OneToMany
+    // mappedBy tells spring that don't create a mapping table instead create a foreign key of user_id
+    // mapped by "bookedBy" in the bookings table
+    // We can use mapped by when we have bidirectional connection
+    @OneToMany(mappedBy = "bookedBy")
     List<Booking> bookings;
+    // JoinColumn(name="bookedBy_id")
+    // this is for the case when we connection only one table say in Bookings we
+    // can tell to spring to create a foreign key(having name bookedBy_id) in bookings table
+
+    @Enumerated(EnumType.ORDINAL)
+    private UserType userType;
 }

--- a/src/main/java/com/jshubham/bookmyshow/models/enums/ScreenStatus.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/enums/ScreenStatus.java
@@ -1,0 +1,7 @@
+package com.jshubham.bookmyshow.models.enums;
+
+public enum ScreenStatus {
+    OPERATIONAL,
+    UNDER_MAINTENANCE,
+    CLOSED
+}

--- a/src/main/java/com/jshubham/bookmyshow/models/enums/ShowSeatStatus.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/enums/ShowSeatStatus.java
@@ -1,7 +1,7 @@
 package com.jshubham.bookmyshow.models.enums;
 
 public enum ShowSeatStatus {
-    AVAIlABLE,
+    AVAILABLE,
     NOT_AVAILABLE, // for seat under maintenance
     BOOKED,
     BLOCKED

--- a/src/main/java/com/jshubham/bookmyshow/models/enums/UserType.java
+++ b/src/main/java/com/jshubham/bookmyshow/models/enums/UserType.java
@@ -1,0 +1,5 @@
+package com.jshubham.bookmyshow.models.enums;
+
+public enum UserType {
+    ADMIN, CUSTOMER
+}

--- a/src/main/java/com/jshubham/bookmyshow/repositories/ShowSeatRepository.java
+++ b/src/main/java/com/jshubham/bookmyshow/repositories/ShowSeatRepository.java
@@ -1,13 +1,24 @@
 package com.jshubham.bookmyshow.repositories;
 
 import com.jshubham.bookmyshow.models.ShowSeat;
+import com.jshubham.bookmyshow.models.enums.ShowSeatStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface ShowSeatRepository extends JpaRepository<ShowSeat, Long> {
     Optional<List<ShowSeat>> findByShowId(Long showId);
-    List<ShowSeat> findAllById(List<Long> id);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<ShowSeat> findById(Long id);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE) // equivalent to select .. for update lock in db
+    @Query("SELECT ss FROM ShowSeat ss WHERE ss.id IN :ids AND ss.status = :status")
+    List<ShowSeat> findAllByIdAndShowSeatStatus(@Param("ids") List<Long> ids, @Param("status") ShowSeatStatus status);
 }

--- a/src/main/java/com/jshubham/bookmyshow/services/ShowService.java
+++ b/src/main/java/com/jshubham/bookmyshow/services/ShowService.java
@@ -1,0 +1,122 @@
+package com.jshubham.bookmyshow.services;
+
+import com.jshubham.bookmyshow.exceptions.*;
+import com.jshubham.bookmyshow.models.*;
+import com.jshubham.bookmyshow.models.enums.Feature;
+import com.jshubham.bookmyshow.models.enums.SeatType;
+import com.jshubham.bookmyshow.models.enums.ShowSeatStatus;
+import com.jshubham.bookmyshow.models.enums.UserType;
+import com.jshubham.bookmyshow.repositories.*;
+import org.hibernate.Hibernate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class ShowService {
+    private UserRepository userRepository;
+    private MovieRepository movieRepository;
+    private ScreenRepository screenRepository;
+    private ShowSeatTypeRepository showSeatTypeRepository;
+    private ShowRepository showRepository;
+    private ShowSeatRepository showSeatRepository;
+    private SeatRepository seatsRepository;
+
+    @Autowired
+    public ShowService(UserRepository userRepository, MovieRepository movieRepository,
+                           ScreenRepository screenRepository, ShowSeatTypeRepository seatTypeShowRepository,
+                           ShowRepository showRepository, SeatRepository seatsRepository,
+                           ShowSeatRepository showSeatRepository) {
+        this.userRepository = userRepository;
+        this.movieRepository = movieRepository;
+        this.screenRepository = screenRepository;
+        this.showSeatTypeRepository = seatTypeShowRepository;
+        this.showRepository = showRepository;
+        this.showSeatRepository = showSeatRepository;
+        this.seatsRepository = seatsRepository;
+    }
+
+    @Transactional
+    public Show createShow(Long userId, Long movieId, Long screenId, Date startTime, Date endTime,
+                           List<Pair<SeatType, Double>> pricingConfig, List<Feature> features)
+            throws MovieNotFoundException, ScreenNotFoundException, FeatureNotSupportedByScreen, InvalidDateException,
+            UserNotFoundException, UnAuthorizedAccessException {
+        // Check for User exists
+        Optional<User> optionalUser = userRepository.findById(userId);
+        if(optionalUser.isEmpty()) throw new UserNotFoundException(getEntityNotFoundExceptionMessage("User", userId));
+        User user = optionalUser.get();
+
+        // Authorized User check
+        if(!user.getUserType().equals(UserType.ADMIN))
+            throw new UnAuthorizedAccessException("User with id: " + " and type " + user.getUserType().name() + " unauthorised to add show details");
+
+        // Check for Movie exists
+        Optional<Movie> optionalMovie = movieRepository.findById(movieId);
+        if(optionalMovie.isEmpty()) throw new MovieNotFoundException(getEntityNotFoundExceptionMessage("Movie", movieId));
+        Movie movie = optionalMovie.get();
+
+        // Check for Screen exists
+        Optional<Screen> optScreen = screenRepository.findById(screenId);
+        if(optScreen.isEmpty()) throw new ScreenNotFoundException(getEntityNotFoundExceptionMessage("Screen", screenId));
+        Screen screen = optScreen.get();
+
+        // Initialize the lazy-loaded collection
+        Hibernate.initialize(screen.getFeatures());
+
+        // Check for valid show period
+        if(startTime.getTime()>=endTime.getTime() || startTime.before(new Date(System.currentTimeMillis()))) throw new InvalidDateException("Show start time: " + startTime.toString() + " is greater than show end time: " + endTime.toString());
+
+        // Validate features
+        List<Feature> screenSupportedFeatures = screen.getFeatures();
+        if (screenSupportedFeatures == null || screenSupportedFeatures.isEmpty()) {
+            throw new FeatureNotSupportedByScreen("Screen does not support any features.");
+        }
+        for (Feature feature : features) {
+            if (!screenSupportedFeatures.contains(feature)) {
+                throw new FeatureNotSupportedByScreen("Screen does not support the feature: " + feature);
+            }
+        }
+
+        Show show = new Show();
+        show.setMovie(movie);
+        show.setScreen(screen);
+        show.setStartTime(startTime);
+        show.setEndTime(endTime);
+        show.setFeatures(features);
+        show = showRepository.save(show);
+
+        // 7. Create and save SeatTypeShow
+        for (Pair<SeatType, Double> pair : pricingConfig) {
+            ShowSeatType showSeatType = new ShowSeatType();
+            showSeatType.setShow(show);
+            showSeatType.setSeatType(pair.getFirst());
+            showSeatType.setPrice(pair.getSecond());
+            showSeatTypeRepository.save(showSeatType);
+        }
+
+        // 8. Create and save ShowSeat
+        List<Seat> seats = seatsRepository.findAll().stream()
+                .filter(seat -> seat.getScreen().getId() == screenId)
+                .collect(Collectors.toList());
+
+        for (Seat seat : seats) {
+            ShowSeat showSeat = new ShowSeat();
+            showSeat.setShow(show);
+            showSeat.setSeat(seat);
+            showSeat.setStatus(ShowSeatStatus.AVAILABLE);
+            showSeatRepository.save(showSeat);
+        }
+
+        return show;
+    }
+
+    private String getEntityNotFoundExceptionMessage(String entityName, Long entityId) {
+        return entityName + " with id: " + entityId + " not found";
+    }
+}


### PR DESCRIPTION
We need to expose a functionality using which theatre admins can create a show. Once this show has been created, users will be able to book tickets for this show on the platform.

### Requirements
**The request to book a ticket will contain the following things:**

- Movie ID - The ID of the movie which is being shown.
- User ID - The ID of the user who is creating the show.
- Screen ID - The ID of the screen where the show is being hosted.
- PricingConfig (List) - The price of each seat type for this show.
- Start Time - The start time of the show.
- End Time - The end time of the show.
- Date - The date on which the show is being hosted.
- Feature List - The list of features that are supported by this show.

1. This functionality should be only accessible to the theatre admin.
2. Every screen has supported features like 2D, 3D, Dolby vision etc. The show that is going to be scheduled on a screen should support all or subset of these features. Example scenarios:
    - If a screen is a 2D screen, then a 3D show cannot be scheduled on it.
    - If a screen supports 3D, 2D, Dolby atmos, then a show which supports 2D and Dolby atmos can be scheduled on it.

- The functionality should do basic data validation checks ex. The start time should be before the end time.
- Once this functionality executes successfully, we should store show details, seats related details for this show and pricing details for this show in the database.